### PR TITLE
Fix regarding ignore variable

### DIFF
--- a/src/juicy-popover.html
+++ b/src/juicy-popover.html
@@ -128,7 +128,7 @@ version: 1.0.0
                 }
             }.bind(this));
 
-            expandable.addEventListener("mouseup", function (ev) {
+            expandable.addEventListener("mousedown", function (ev) {
                 ignore = true;
             }.bind(this));
 


### PR DESCRIPTION
This change won't collapse the expandable if mousedown is on expandableselector, but mouseup is not; for Starcounter/Home#158 .