### PR TITLE
Bump hoek version to avoid security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1333,7 +1333,7 @@
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "5.0.3"
       }
     },
     "boxen": {
@@ -3132,7 +3132,7 @@
       "requires": {
         "boom": "2.10.1",
         "cryptiles": "2.0.5",
-        "hoek": "2.16.3",
+        "hoek": "5.0.3",
         "sntp": "1.0.9"
       }
     },
@@ -3143,8 +3143,8 @@
       "dev": true
     },
     "hoek": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
       "dev": true
     },
@@ -5826,7 +5826,7 @@
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
       "dev": true,
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "5.0.3"
       }
     },
     "socket.io": {


### PR DESCRIPTION
I'm not sure if I did it right, because It's my first time updating package-lock.json. Let me know if I should do some more steps than just updating version number at every occurrence in this file.